### PR TITLE
Add support for clang-tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Currently, the plugin supports the following diagnostic sources:
 
 * basedpyright
 * LuaLS
+* clang-tidy
 
-Hush exposes two commands - `:Hush` and `:HushAll`. `Hush` tries to silence the specific warnings emitted by the line using their error codes. `HushAll` disables the offended source for the line.
+Hush exposes two commands - `:Hush` and `:HushAll`. `Hush` tries to silence the specific warnings emitted by the line using their error codes (if it's not supported in the source, it falls back to `HushAll`. `HushAll` disables the offended source for the line (if it's not supported in the source, falls back to `Hush`.
 
 
 ## Development

--- a/lua/hush/sources/clang-tidy.lua
+++ b/lua/hush/sources/clang-tidy.lua
@@ -1,0 +1,24 @@
+local utils = require("hush.sources.utils")
+---@class ClangTidyDiagnosticSource: DiagnosticSource
+
+---@class ClangTidyDiagnosticSource
+local CT = {}
+
+CT.comment_position = "above"
+
+CT.build_suppress_all_diagnostics = function()
+  return "// NOLINTNEXTLINE"
+end
+
+CT.build_suppress_diagnostics = function(diagnostics)
+  local codes = utils.get_sources_from_diagnostics(diagnostics)
+  local codes_str = table.concat(codes, ", ")
+
+  return "// NOLINTNEXTLINE( " .. codes_str .. " )"
+end
+
+CT.matches_diagnostic = function(diagnostic)
+  return diagnostic.source == "clang-tidy"
+end
+
+return CT

--- a/lua/hush/sources/init.lua
+++ b/lua/hush/sources/init.lua
@@ -1,13 +1,16 @@
 local M = {}
 local basedpyright = require("hush.sources.basedpyright")
 local lua_ls = require("hush.sources.lua_ls")
+local clang_tidy = require("hush.sources.clang-tidy")
 
 M.all = {
   basedpyright,
   lua_ls,
+  clang_tidy,
 }
 
 M.basedpyright = basedpyright
 M.lua_ls = lua_ls
+M.clang_tidy = clang_tidy
 
 return M


### PR DESCRIPTION
- **refactor: don't check for the local commentstring, define it as parts of comments instead**
- **refactor,feat: add lua_ls support, improve abstraction in the base source**
- **doc: update readme**
- **fix: match the indent when adding suppressing above the offending line**
- **feat: allow falling back to build_suppress_diagnostics in build_suppress_all_diagnostics, do it for lua_ls**
- **doc: fix readme linter error**
- **doc: update list of supported sources**
- **feat: add support for clang-tidy**
